### PR TITLE
systemd version toggle and jinja2; minor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ vault_config:
   storage: 'file'
 ```
 
-Controls how Vault's sealing mechanism. This data is used in the templated out `vault.hcl` file.
+`vault_seal_type` controls Vault's sealing mechanism. This data is used in the templated out `vault.hcl` file.
+Options are: `shamir`, `pkcs11`, and `gcpkms`.
 ```yaml
 seal:
   type: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,15 +19,20 @@ vault_http_port: '8200'
 vault_api_port: '8201'
 vault_ui: true
 
+# options: file, integrated, consul
 vault_storage_backend: 'file'
 vault_disable_mlock: false
 
+# options: shamir, pkcs11, gcpkms
 vault_seal_type: 'shamir'
 
 vault_tls_disable: true
 vault_tls_directory: '{{ vault_home_directory }}/tls'
 vault_tls_cert_file: 'tls/dc1-server-consul-0.pem'
 vault_tls_key_file: 'tls/dc1-server-consul-0-key.pem'
+
+# Set to false on RHEL7 (systemd v219). Otherwise unit file includes invalid parameters for this systemd version.
+vault_newsystemdversion: true
 
 consul_http_port: '8500'
 consul_scheme: 'http'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -133,3 +133,4 @@
     name: vault
     enabled: yes
     state: started
+    daemon_reload: yes

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -133,4 +133,3 @@
     name: vault
     enabled: yes
     state: started
-    daemon_reload: yes

--- a/templates/vault.systemd.j2
+++ b/templates/vault.systemd.j2
@@ -37,8 +37,12 @@ KillSignal=SIGINT
 Restart=on-failure
 RestartSec=5
 TimeoutStopSec=30
+{% if vault_newsystemdversion == True %}
+# StartLimitIntervalSec and StartLimitBurst are available in later systemd version (check your version with systemctl --version)
+# e.g., these two options cannot be used with RHEL7 (systemd 219) and starting the Vault service would error out
 StartLimitIntervalSec=60
 StartLimitBurst=3
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add variable to toggle between systemd older and newer systems versions.
Systemd version 219 on RHEL 7 for example is too old for two parameters in the Vault unit file. Vault would fail to start with these parameters.

Minor doc updates to show what options are available for seal and storage.

Explicit daemon-reload on last task, as it created a problem for me on second run of the playbook not having it.