### PR TITLE
fix identation in uninstall playbook; add warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ vault_newsystemdversion: true
 
 `vault_home_usr` toggles aspects of systemd sandboxing if the Vault home and data directory are in the `/usr` folder. If so, system unit ProtectSystem
 parameters cannot be used, reference: [Sandboxing](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Sandboxing).
+> :warning: **Warning:** Setting this to `true` weakens your security posture! Don't set home and data to a path in `/usr` if you can avoid it!
 
 ```yaml
 vault_home_usr: false

--- a/uninstall.yaml
+++ b/uninstall.yaml
@@ -5,13 +5,13 @@
   tasks:
     - name: stopping vault service
       systemd:
-      name: vault
-      state: stopped
+        name: vault
+        state: stopped
       
     - name: removing all Vault files and directories
       file:
-      path: '{{ item }}'
-      state: absent
+        path: '{{ item }}'
+        state: absent
       with_items:
       - '/etc/systemd/system/vault.service'
       - '{{ vault_home_directory }}'
@@ -20,18 +20,18 @@
     
     - name: removing vault user
       user:
-      name: '{{ vault_user }}'
-      state: absent
-      remove: yes
+        name: '{{ vault_user }}'
+        state: absent
+        remove: yes
     
     - name: removing vault user
       group:
-      name: '{{ vault_group }}'
-      state: absent
+        name: '{{ vault_group }}'
+        state: absent
       
     - name: removing vault dependencies
       package:
-      name:
+        name:
         - unzip
         - curl
-      state: absent
+        state: absent


### PR DESCRIPTION
Fixes #7  
Fix indentation in uninstall playbook
Add warning and discourage moving Vault into `/usr`.